### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ There are undoubtably bugs but I've used this library in all 8 apps I have in th
 
 The included library assumes ARC style memory management. It's also been arbitrarily set to support iOS 7 and up. I've moved to using newer code annotations such as *nullable* so it requires a recent version of Xcode to compile. Supports both traditional and module based framework includes.
 
-Originally, this was distributed as a static library, but that is not a modern way to use it. So the enclosed project will build a framework, and most developers will probably find the use of **Cocoapods** more enjoyable. Requires Cocoapods 0.39 or above.
+Originally, this was distributed as a static library, but that is not a modern way to use it. So the enclosed project will build a framework, and most developers will probably find the use of **CocoaPods** more enjoyable. Requires CocoaPods 0.39 or above.
 
-I've enabled **IB_DESIGNABLE** for the view classes for environments with a minimum OS version of iOS 8 and above. This will allow artwork and widgets to be visible in Interface Builder. Cocoapods users should put ````use_frameworks!```` in their Podfile.
+I've enabled **IB_DESIGNABLE** for the view classes for environments with a minimum OS version of iOS 8 and above. This will allow artwork and widgets to be visible in Interface Builder. CocoaPods users should put ````use_frameworks!```` in their Podfile.
 
 The segmented control is not ready for use in tvOS apps. 
 
@@ -37,14 +37,14 @@ If you just want to use the code in your app and are uninterested in the underly
 * SVGToPDFConverter.h A class to convert the renderer's contents to a PDF.
 * SVGPrinter.h A class to send a renderer's contents to a printer.
 
-####If you are familiar with using Cocoapods and using it in your project
+####If you are familiar with using CocoaPods and using it in your project
 * Insert ````pod 'SVGgh'```` into your PodFile
 • If you set your deployment target to iOS 8 or above, you should insert 
 ````use_frameworks!```` in your Podfile. 
 
-* Go through the standard procedures for updating your Xcode workspace via Cocoapods. ````pod update````, ````pod install````, etc.
+* Go through the standard procedures for updating your Xcode workspace via CocoaPods. ````pod update````, ````pod install````, etc.
 
-####If you are not using Cocoapods
+####If you are not using CocoaPods
 To compile the framework. 
 * Load the included **SVGgh.xcodeproj** project in Xcode 6.3 or above 
 * **Build** the **Framework** target.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
