### PR TITLE
Add support for inline style `opacity`

### DIFF
--- a/SVGgh/SVG/SVGAttributedObject.m
+++ b/SVGgh/SVG/SVGAttributedObject.m
@@ -718,6 +718,20 @@
         if(strokeOpacity > 1.0) strokeOpacity = 1.0;
     }
     
+    
+    NSString* opacityString = [self valueForStyleAttribute:@"opacity" withSVGContext:svgContext];
+    CGFloat opacity = 1.0;
+    if([opacityString length])
+    {
+        opacity = [opacityString floatValue];
+        if(opacity < 0.0) opacity = 0.0;
+        if(opacity > 1.0) opacity = 1.0;
+    }
+    
+    if (opacity != 1.0) {
+        CGContextSetAlpha(quartzContext, opacity);
+    }
+    
     BOOL	fillIt = (fillOpacity > 0.0 && ![fillString isEqualToString:@"none"]);
     
     if(fillIt && self.isFillable)


### PR DESCRIPTION
Hi Glenn,

Just discovered this project, awesome work! Thank you! I'm trying to render SVGs outputted from Adobe Illustrator with inline styles and they are rendering accurately (and really fast) but it looks like Illustrator is using the `opacity` style for their inline styles and not `fill-opacity`.

Relevant output of Illustrator: 
`<path d="M1348 1414c-7 12-20 4-30 5-12 2-19 9-32 7-8-1-12-3-20-1-6 1-12 4-18 4-14 0-24-15-37-12 5-17 14-62-9-70-8-2-27 7-35 7-12 1-21-1-31-8-4-2-17-15-21-9s7 17 11 21c19 16 48 11 70 5-2 8-1 17-2 25-14-22-39-3-42 17-2 18 13 40 32 28-7 19 23 11 31 12 15 2 21 9 37 6 13-4 19-3 32-1s20-3 33-6c9-2 17 3 27 1s23-11 25-21c3-12-13-22-21-10l3-5-3 5z" style="fill:#565656;opacity:.5"/>`

Here is the modification to support it. :)

SVG 1.1 Spec: https://www.w3.org/TR/SVG/masking.html#OpacityProperty
More Info: http://stackoverflow.com/questions/37759898/opacity-vs-fill-opacity-in-svg