### PR TITLE
Fixed `getBoundingBox` methods always returning x: 0, y: 0 rects

### DIFF
--- a/SVGgh/SVG/SVGAttributedObject.m
+++ b/SVGgh/SVG/SVGAttributedObject.m
@@ -1641,12 +1641,6 @@
         if([aChild environmentOKWithSVGContext:svgContext])
         {
             CGRect childRect = [aChild getBoundingBoxWithSVGContext:svgContext];
-            if (CGPointEqualToPoint(childRect.origin, CGPointZero)){
-                [aChild getBoundingBoxWithSVGContext:svgContext];
-                NSLog(@"T: %@", NSStringFromCGRect(childRect));
-                NSLog(@"c: %@", aChild);
-                continue;
-            }
             if(!CGRectIsNull(result) && !CGRectIsNull(childRect))
             {
                 result = CGRectUnion(result, childRect);

--- a/SVGgh/SVG/SVGAttributedObject.m
+++ b/SVGgh/SVG/SVGAttributedObject.m
@@ -277,7 +277,7 @@
 }
 -(CGRect) getBoundingBoxWithSVGContext:(id<SVGContext>)svgContext
 {// base class doesn't know how to do this.
-    CGRect result = CGRectZero;
+    CGRect result = CGRectNull;
     return result;
 }
 
@@ -659,7 +659,7 @@
 
 -(CGRect) getBoundingBoxWithSVGContext:(id<SVGContext>)svgContext
 {
-    CGRect result = CGRectZero;
+    CGRect result = CGRectNull;
     CGPathRef basePath = self.quartzPath;
     if(basePath)
     {
@@ -1634,13 +1634,19 @@
 
 -(CGRect) getBoundingBoxWithSVGContext:(id<SVGContext>)svgContext
 {
-    CGRect result = CGRectZero;
+    CGRect result = CGRectNull;
     NSArray* myChildren = self.children;
     for(id aChild in myChildren)
     {
         if([aChild environmentOKWithSVGContext:svgContext])
         {
             CGRect childRect = [aChild getBoundingBoxWithSVGContext:svgContext];
+            if (CGPointEqualToPoint(childRect.origin, CGPointZero)){
+                [aChild getBoundingBoxWithSVGContext:svgContext];
+                NSLog(@"T: %@", NSStringFromCGRect(childRect));
+                NSLog(@"c: %@", aChild);
+                continue;
+            }
             if(!CGRectIsNull(result) && !CGRectIsNull(childRect))
             {
                 result = CGRectUnion(result, childRect);
@@ -2210,7 +2216,7 @@
 
 -(CGRect) getBoundingBoxWithSVGContext:(id<SVGContext>)svgContext
 {// base class doesn't know how to do this.
-    CGRect result = CGRectZero;
+    CGRect result = CGRectNull;
     NSMutableSet*   exclusionSet = nil;
     id<GHRenderable> myConcrete = [self concreteObjectForSVGContext:svgContext excludingPrevious:exclusionSet];
     if(myConcrete != self)


### PR DESCRIPTION
When using the `getBoundingBox` methods I noticed it was always returning a rect that had a x: 0, y: 0.  
This was due to using `CGRectZero` instead of `CGRectNull` in conjunction with `CGRectUnion` for the `result` variable.  
`CGRectIsNull` is used to check the `result` so my guess is `CGRectIsNull` was always intended to be the initial value for the `result` variable.