### PR TITLE
Fix build with Xcode 11 beta3 due to ambiguous reference to property:…

### DIFF
--- a/SVGgh/SVG/GHAttributedObject.h
+++ b/SVGgh/SVG/GHAttributedObject.h
@@ -33,10 +33,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol GHAttributedObjectProtocol <NSObject>
+@property (copy, nonatomic, readonly) NSDictionary*      attributes;
+@property (readonly, nonatomic)  NSString* __nullable entityName;
+@end
 
 /*! @brief basically just a wrapper around an NSDictionary. A convenient object when generating from XML
 */
-@interface GHAttributedObject : NSObject
+@interface GHAttributedObject : NSObject <GHAttributedObjectProtocol>
 @property (copy, nonatomic, readonly) NSDictionary*  	attributes;
 @property (readonly, nonatomic)  NSString* __nullable entityName;
 

--- a/SVGgh/SVG/SVGAttributedObject.m
+++ b/SVGgh/SVG/SVGAttributedObject.m
@@ -37,7 +37,7 @@
 
 @interface GHAttributedObject(SVGRenderer)
 
-+(NSDictionary*) overideObjectsForPrototype:(id)prototype withDictionary:(NSDictionary*)deltaDictionary;
++(NSDictionary*) overideObjectsForPrototype:(id<GHAttributedObjectProtocol>)prototype withDictionary:(NSDictionary*)deltaDictionary;
 -(instancetype) cloneWithOverridingDictionary:(NSDictionary*)overrideAttributes;
 @end
 
@@ -50,7 +50,7 @@
 
 @implementation GHAttributedObject(SVGRenderer)
 
-+(NSDictionary*) overideObjectsForPrototype:(id)prototype withDictionary:(NSDictionary*)deltaDictionary
++(NSDictionary*) overideObjectsForPrototype:(id<GHAttributedObjectProtocol>)prototype withDictionary:(NSDictionary*)deltaDictionary
 {
     NSDictionary* result = nil;
     if([prototype respondsToSelector:@selector(attributes)])


### PR DESCRIPTION
… NSDictionary *attributes
Xcode 11 beta complier complains that there are many 'attributes' properties declared with different return types.
```
/.../SVGgh/SVGgh/SVG/SVGAttributedObject.m:58:54: error: multiple methods named 'attributes' found with mismatched result, parameter type or attributes
        NSDictionary* oldAttributes = (NSDictionary*)[prototype attributes];
```

To fix this,
1. Defined GHAttributedObjectProtocol 
2. Take id<GHAttributedObjectProtocol> instead of 'id' as input parameter type from +overideObjecctsForPrototype:withDictionary: of GHAttributedObject

